### PR TITLE
Replace unknown with any type in SandboxVars

### DIFF
--- a/yml/shared/Sandbox/SandboxVars.yml
+++ b/yml/shared/Sandbox/SandboxVars.yml
@@ -7,7 +7,7 @@ languages:
           - StubGen_Extra
         fields:
           "[string]":
-            type: unknown
+            type: any
           Basement:
             type: umbrella.SandboxVars.Basement
           Map:


### PR DESCRIPTION
Fixes the `undefined-field` issue with SandboxVars when you index it with a string.